### PR TITLE
Fix e2e tests and improve debuggability

### DIFF
--- a/charts/aws-overlay-example/Chart.yaml
+++ b/charts/aws-overlay-example/Chart.yaml
@@ -25,11 +25,11 @@ appVersion: "latest"
 
 dependencies:
 - name: xrd-vrouter
-  version: ">= 1.0.0"
+  version: "~1.0.0-0"
   repository: "https://ios-xr.github.io/xrd-helm"
   alias: xrd1
 - name: xrd-vrouter
-  version: ">= 1.0.0"
+  version: "~1.0.0-0"
   repository: "https://ios-xr.github.io/xrd-helm"
   alias: xrd2
 - name: simple-host

--- a/test/.taskcat.yml
+++ b/test/.taskcat.yml
@@ -20,11 +20,13 @@ general:
     RemoteAccessCIDR: "0.0.0.0/0"
     EKSPublicAccessEndpoint: Enabled
 
+    Platform: VRouter
+
 
 project:
   # Sets key prefix for all files within an S3 bucket.
   # This must be kept in sync with publish-s3-bucket and create-stack
-  name: 'dev'
+  name: xrd-eks
 
 tests:
   # Example to create an AMI suitable for XRd vRouter.

--- a/test/.taskcat.yml
+++ b/test/.taskcat.yml
@@ -20,8 +20,10 @@ general:
     RemoteAccessCIDR: "0.0.0.0/0"
     EKSPublicAccessEndpoint: Enabled
 
+    # This should not be necessary (for overlay applications), but taskcat
+    # requires all parameters are provided, even if they are conditionally
+    # not required.
     Platform: VRouter
-
 
 project:
   # Sets key prefix for all files within an S3 bucket.

--- a/test/_common.py
+++ b/test/_common.py
@@ -22,7 +22,7 @@ from tenacity import (
 def get_running_xrd_pods(
     k8s: kubernetes.client.CoreV1Api,
     *,
-    num_expected: Optional[int],
+    num_expected: Optional[int] = None,
 ) -> list[kubernetes.client.V1Pod]:
     """Returns a list of running XRd pods.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -135,13 +135,13 @@ def repository(request: pytest.FixtureRequest) -> str:
     assert (
         "control_plane" in marks or "vrouter" in marks,
         "Nodes using the `repository` fixture must be marked `control_plane` "
-        "or `vrouter`"
+        "or `vrouter`",
     )
 
     assert (
         not ("control_plane" in marks and "vrouter" in marks),
         "Nodes using the `repository` fixture must not be marked both "
-        "`control_plane` and `vrouter`"
+        "`control_plane` and `vrouter`",
     )
 
     if "control_plane" in marks:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -118,7 +118,7 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
     ...     yield
     ...     result = getattr(request.node, "result", None)
     ...     if result is not None and result.failed:
-    ...         # Run-on-failure.
+    ...         # Commands to run-on-failure.
 
     """
     outcome = yield

--- a/test/helm/helm/__init__.py
+++ b/test/helm/helm/__init__.py
@@ -44,6 +44,7 @@ class Helm:
                 "-f",
                 f.name,
                 "--reuse-values",
+                "--devel",
             )
 
     def rollback(self, *, revision: int = 1) -> None:
@@ -66,6 +67,7 @@ def install(
         "-o",
         "json",
         "--dependency-update",
+        "--devel",
     ]
 
     with tempfile.NamedTemporaryFile(mode="w") as f:


### PR DESCRIPTION
A few minor changes to fix the e2e tests.

* Change the version of the singleton Helm charts that `aws-overlay-example` uses so that it picks up the released beta versions.
* Add `Platform` parameter to the taskcat config.  This should not be necessary, because `Platform` is not actually needed to create the Overlay stack, but taskcat (rather than aws/boto) complains if we don't provide it.
* Fix an issue with upgrade tests where the pods in the "old" revision are checked for termination on test end, rather than the "new" revision.
* Fix an issue with the tests where if a failure is hit when creating the CF stacks, the stacks are not properly cleaned up.
* Improve test debuggability by collecting some diags on test failure.
