### PR TITLE
Fix argument parsing in publish-ecr

### DIFF
--- a/publish-ecr
+++ b/publish-ecr
@@ -20,17 +20,12 @@ show_help() {
     >&2 echo " -p, --platform PLATFORM  XRd platform the image is for"
     >&2 echo "                          (defaults to checking the image name)"
     >&2 echo " -t, --tag TAG            Override the target image tag"
+    >&2 echo "                          (defaults to 'latest')"
     >&2 echo ""
     >&2 echo "This script requires skopeo when publishing an image archive."
     >&2 echo "When publishing from a repository, at least one of skopeo,"
     >&2 echo "docker, or podman must be available."
 }
-
-if [ $# -lt 1 ]; then
-  >&2 echo "Not enough positional arguments specified"
-  show_help
-  exit 1
-fi
 
 POSITIONAL_ARGS=()
 
@@ -67,7 +62,7 @@ if [ ${#POSITIONAL_ARGS[@]} -ne 1 ]; then
   exit 1
 fi
 
-SOURCE_IMAGE=${POSITIONAL_ARGS[1]}
+SOURCE_IMAGE=${POSITIONAL_ARGS[0]}
 
 if [ -n "${PLATFORM:-}" ]; then
   if [ "$(echo "$PLATFORM" | tr "[:upper:]" "[:lower:]")" = "vrouter" ]; then

--- a/publish-ecr
+++ b/publish-ecr
@@ -32,8 +32,7 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
-SOURCE_IMAGE=$1
-shift
+POSITIONAL_ARGS=()
 
 # Parse the arguments
 while [ $# -gt 0 ]; do
@@ -50,14 +49,25 @@ while [ $# -gt 0 ]; do
       show_help
       exit 255
       ;;
-    * )
+    -* )
       >&2 echo "Unknown option $1"
       show_help
       exit 1
       ;;
+    * )
+      POSITIONAL_ARGS+=("$1")
+      ;;
   esac
   shift
 done
+
+if [ ${#POSITIONAL_ARGS[@]} -ne 1 ]; then
+  >&2 echo "Exactly one positional arg required: SOURCE_IMAGE"
+  show_help
+  exit 1
+fi
+
+SOURCE_IMAGE=${POSITIONAL_ARGS[1]}
 
 if [ -n "${PLATFORM:-}" ]; then
   if [ "$(echo "$PLATFORM" | tr "[:upper:]" "[:lower:]")" = "vrouter" ]; then

--- a/publish-s3-bucket
+++ b/publish-s3-bucket
@@ -8,6 +8,28 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+show_help() {
+    >&2 echo "Usage: publish-s3-bucket [-h]"
+    >&2 echo ""
+    >&2 echo "Publish an S3 bucket with the resources from this repository."
+    >&2 echo "Must be run from the root of the xrd-eks repository."
+}
+
+# Parse the arguments
+while [ $# -gt 0 ]; do
+  case $1 in
+    -h|--help )
+      show_help
+      exit 255
+      ;;
+    * )
+      >&2 echo "Unknown option $1"
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
 ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
 BUCKET_NAME=${BUCKET_NAME:-"${ACCOUNT_ID}-xrd-quickstart"}
 BUCKET_KEY_PREFIX=${BUCKET_KEY_PREFIX:-"xrd-eks/"}


### PR DESCRIPTION
Fixes #3 

Now `publish-ecr --help` actually displays the help:

```zsh
➜  xrd-eks git:(hotfix/publish-ecr-help) ./publish-ecr -h
Usage: publish-ecr SOURCE_IMAGE [-p PLATFORM] [-t TAG]

Publish an XRd container image to ECR

Required arguments:
 SOURCE_IMAGE         Either a path to a local image tarball or
                      a URL to an image repository (with tag)

Optional arguments:
 -h, --help               Show this help
 -p, --platform PLATFORM  XRd platform the image is for
                          (defaults to checking the image name)
 -t, --tag TAG            Override the target image tag

This script requires skopeo when publishing an image archive.
When publishing from a repository, at least one of skopeo,
docker, or podman must be available.
```