### PR TITLE
Allow a subnet ID to be specified in the AMI creation CF

### DIFF
--- a/cf-templates/xrd-eks-ami-cf.yaml
+++ b/cf-templates/xrd-eks-ami-cf.yaml
@@ -35,8 +35,13 @@ Parameters:
     Type: String
     Default: m5.2xlarge
 
+  SubnetId:
+    Description: Subnet where the instance building the AMI is launched. If left empty this uses the default subnet.
+    Type: String
+
 Conditions:
   EnsureEksQsSharedResources: !Equals [ !Ref EksQsSharedResources, 'AutoDetect' ]
+  SubnetIdProvided: !Not [ !Equals [ !Ref SubnetId, '' ] ]
 
 Resources:
 
@@ -76,6 +81,7 @@ Resources:
     Properties:
       ImageId: !Ref BaseImageId
       InstanceType: !Ref InstanceType
+      SubnetId: !If [ SubnetIdProvided, !Ref SubnetId, !Ref AWS::NoValue ]
       UserData:
         "Fn::Base64": !Sub
           - |-


### PR DESCRIPTION
Allow a subnet ID to be specified in the AMI cloudformation.

Some accounts don't have a default VPC so must specify the subnet.
If this field is left blank the old behaviour (i.e picking one automatically) is obtained.

Tested building AMIs both with and without the new field specified.