### PR TITLE
Add socket kernel parameters; add NODE_INSTANCE_TYPE option

### DIFF
--- a/cf-templates/xrd-eks-node-launch-template-cf.yaml
+++ b/cf-templates/xrd-eks-node-launch-template-cf.yaml
@@ -439,6 +439,8 @@ Resources:
 
                   echo "fs.inotify.max_user_instances=64000" >> /etc/sysctl.d/50-xrd.conf
                   echo "fs.inotify.max_user_watches=64000" >> /etc/sysctl.d/50-xrd.conf
+                  echo "kernel.randomize_va_space=2" >> /etc/sysctl.d/50-xrd.conf
+                  echo "kernel.sched_rt_runtime_us=-1" >> /etc/sysctl.d/50-xrd.conf
                   echo "net.core.rmem_max=67108864" >> /etc/sysctl.d/50-xrd.conf
                   echo "net.core.wmem_max=67108864" >> /etc/sysctl.d/50-xrd.conf
                   echo "net.core.rmem_default=67108864" >> /etc/sysctl.d/50-xrd.conf

--- a/cf-templates/xrd-eks-node-launch-template-cf.yaml
+++ b/cf-templates/xrd-eks-node-launch-template-cf.yaml
@@ -440,7 +440,6 @@ Resources:
                   echo "fs.inotify.max_user_instances=64000" >> /etc/sysctl.d/50-xrd.conf
                   echo "fs.inotify.max_user_watches=64000" >> /etc/sysctl.d/50-xrd.conf
                   echo "kernel.randomize_va_space=2" >> /etc/sysctl.d/50-xrd.conf
-                  echo "kernel.sched_rt_runtime_us=-1" >> /etc/sysctl.d/50-xrd.conf
                   echo "net.core.rmem_max=67108864" >> /etc/sysctl.d/50-xrd.conf
                   echo "net.core.wmem_max=67108864" >> /etc/sysctl.d/50-xrd.conf
                   echo "net.core.rmem_default=67108864" >> /etc/sysctl.d/50-xrd.conf

--- a/cf-templates/xrd-eks-node-launch-template-cf.yaml
+++ b/cf-templates/xrd-eks-node-launch-template-cf.yaml
@@ -439,6 +439,13 @@ Resources:
 
                   echo "fs.inotify.max_user_instances=64000" >> /etc/sysctl.d/50-xrd.conf
                   echo "fs.inotify.max_user_watches=64000" >> /etc/sysctl.d/50-xrd.conf
+                  echo "net.core.rmem_max=67108864" >> /etc/sysctl.d/50-xrd.conf
+                  echo "net.core.wmem_max=67108864" >> /etc/sysctl.d/50-xrd.conf
+                  echo "net.core.rmem_default=67108864" >> /etc/sysctl.d/50-xrd.conf
+                  echo "net.core.wmem_default=67108864" >> /etc/sysctl.d/50-xrd.conf
+                  echo "net.core.netdev_max_backlog=300000" >> /etc/sysctl.d/50-xrd.conf
+                  echo "net.core.optmem_max=67108864" >> /etc/sysctl.d/50-xrd.conf
+                  echo "net.ipv4.udp_mem=1124736 10000000 67108864" >> /etc/sysctl.d/50-xrd.conf
                   sysctl -p --system
                   ${VRouterSetup}
                   ${ProxySetup}

--- a/create-stack
+++ b/create-stack
@@ -124,6 +124,7 @@ TEMPLATE_URL="${BUCKET_URL_PREFIX}cf-templates/${TEMPLATE_NAME}"
 CAPABILITIES="CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND"
 CLUSTER_NAME="xrd-cluster"
 KEY_PAIR_NAME="${KEY_PAIR_NAME:-${USER}}"
+NODE_INSTANCE_TYPE=${NODE_INSTANCE_TYPE:-"m5.2xlarge"}
 
 function add_parameter {
     KEY=$1
@@ -142,7 +143,7 @@ add_parameter RemoteAccessCIDR "0.0.0.0/0"
 add_parameter EKSPublicAccessEndpoint "Enabled"
 add_parameter KeyPairName "${KEY_PAIR_NAME}"
 
-add_parameter NodeInstanceType "m5.2xlarge"
+add_parameter NodeInstanceType "${NODE_INSTANCE_TYPE}"
 
 add_parameter Application "${APPLICATION}"
 add_parameter Platform "${PLATFORM}"


### PR DESCRIPTION
Update the EC2 sysctl settings to include all the socket kernel parameters required by XRd for production deployments at high scale.

Also add a NODE_INSTANCE_TYPE option to create-stack, to make it easier to launch m5.24xlarge instances.