### PR TITLE
Fix publish-s3-bucket for us-east-1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     }
 
     environment {
-        BUCKET_NAME = """${sh script: "aws sts get-caller-identity --query 'Account' --output text", returnStdout: true trim}-xrd-quickstart"""
+        BUCKET_NAME = """${sh script: "aws sts get-caller-identity --query 'Account' --output text", returnStdout: true trim()}-xrd-quickstart"""
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     }
 
     environment {
-        BUCKET_NAME = """${sh "aws sts get-caller-identity --query 'Account' --output text", returnStdout: true trim}-xrd-quickstart"""
+        BUCKET_NAME = """${sh script: "aws sts get-caller-identity --query 'Account' --output text", returnStdout: true trim}-xrd-quickstart"""
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,8 +10,18 @@ pipeline {
         string(name: "xrd_vrouter_tags")
     }
 
+    environment {
+        BUCKET_NAME = """${sh "aws sts get-caller-identity --query 'Account' --output text", returnStdout: true trim}-xrd-quickstart"""
+    }
+
     stages {
-        stage("Publish CF templates and Helm charts") {
+        stage("Remove existing XRd S3 bucket") {
+            steps {
+                sh "aws s3 rb s3://${env.BUCKET_NAME} --force"
+            }
+        }
+
+        stage("Publish XRd S3 bucket") {
             steps {
                 sh "./publish-s3-bucket"
             }
@@ -19,15 +29,15 @@ pipeline {
 
         stage("Run tests") {
             steps {
-                sh "nox -f test/noxfile.py --                                  \
-                        --aws-region ${params.aws_region}                      \
+                sh "nox -f test/noxfile.py --                                 \
+                        --aws-region ${params.aws_region}                     \
                         --eks-kubernetes-version ${params.eks_kubernetes_version} \
                         --xrd-control-plane-repository ${params.xrd_control_plane_repository} \
                         --xrd-control-plane-tags ${params.xrd_control_plane_tags} \
                         --xrd-vrouter-repository ${params.xrd_vrouter_repository} \
-                        --xrd-vrouter-tags ${params.xrd_vrouter_tags}          \
-                        --log-file all.log                                     \
-                        --log-file-level debug                                 \
+                        --xrd-vrouter-tags ${params.xrd_vrouter_tags}         \
+                        --log-file all.log                                    \
+                        --log-file-level debug                                \
                         --junitxml results.xml"
             }
         }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The following are optional:
 
 More details are provided for each below.
 
-### Submodules
+#### Submodules
 
 All submodules in this git repository must be checked out recursively.
 

--- a/publish-s3-bucket
+++ b/publish-s3-bucket
@@ -79,7 +79,7 @@ git submodule status --recursive 2>/dev/null | while IFS= read -r LINE; do
     if [ "${LINE:0:1}" = "-" ]; then
         2>&1 echo "Submodules are not recursively checked out."
         2>&1 echo "Run 'git submodule update --init --recursive' and try again."
-        exit 2
+        exit 1
     fi
 done
 

--- a/publish-s3-bucket
+++ b/publish-s3-bucket
@@ -41,7 +41,11 @@ AMI_ASSETS_DIR=ami_assets
 SUBMODULES_DIR=submodules
 
 create_bucket() {
-    aws s3api head-bucket --bucket "${BUCKET_NAME}" >/dev/null || aws s3api create-bucket --bucket "${BUCKET_NAME}" --create-bucket-configuration "{ \"LocationConstraint\": \"${AWS_REGION}\" }"
+    if [ "${AWS_REGION}" != "us-east-1" ]; then
+        aws s3api head-bucket --bucket "${BUCKET_NAME}" >/dev/null || aws s3api create-bucket --bucket "${BUCKET_NAME}" --create-bucket-configuration "{ \"LocationConstraint\": \"${AWS_REGION}\" }"
+    else
+        aws s3api head-bucket --bucket "${BUCKET_NAME}" >/dev/null || aws s3api create-bucket --bucket "${BUCKET_NAME}"
+    fi
 
     POLICY='{
         "Version": "2012-10-17",

--- a/publish-s3-bucket
+++ b/publish-s3-bucket
@@ -74,6 +74,15 @@ sync_dir() {
     aws s3 sync --delete "./${DIR}/" "s3://${BUCKET_NAME}/${BUCKET_KEY_PREFIX}${DIR}/"
 }
 
+echo "Checking git submodules are recursively checked out..."
+git submodule status --recursive 2>/dev/null | while IFS= read -r LINE; do
+    if [ "${LINE:0:1}" = "-" ]; then
+        2>&1 echo "Submodules are not recursively checked out."
+        2>&1 echo "Run 'git submodule update --init --recursive' and try again."
+        exit 2
+    fi
+done
+
 echo "Creating bucket ${BUCKET_NAME}..."
 create_bucket
 

--- a/publish-s3-bucket
+++ b/publish-s3-bucket
@@ -42,9 +42,9 @@ SUBMODULES_DIR=submodules
 
 create_bucket() {
     if [ "${AWS_REGION}" != "us-east-1" ]; then
-        aws s3api head-bucket --bucket "${BUCKET_NAME}" >/dev/null || aws s3api create-bucket --bucket "${BUCKET_NAME}" --create-bucket-configuration "{ \"LocationConstraint\": \"${AWS_REGION}\" }"
+        aws s3api head-bucket --bucket "${BUCKET_NAME}" >/dev/null 2>&1 || aws s3api create-bucket --bucket "${BUCKET_NAME}" --create-bucket-configuration "{ \"LocationConstraint\": \"${AWS_REGION}\" }"
     else
-        aws s3api head-bucket --bucket "${BUCKET_NAME}" >/dev/null || aws s3api create-bucket --bucket "${BUCKET_NAME}"
+        aws s3api head-bucket --bucket "${BUCKET_NAME}" >/dev/null 2>&1 || aws s3api create-bucket --bucket "${BUCKET_NAME}"
     fi
 
     POLICY='{

--- a/test/test_overlay.py
+++ b/test/test_overlay.py
@@ -3,11 +3,12 @@
 """End-to-end tests for the Overlay application."""
 
 
-import pytest
 import subprocess
 
+import pytest
+
 from . import utils
-from ._types import Image, Kubectl, Platform
+from ._types import Kubectl, Platform
 from .helm import Helm
 
 
@@ -111,7 +112,9 @@ def test_quickstart(kubectl: Kubectl, helm: Helm) -> None:
             f"{expected_release_name}-xrd1-0",
             address,
         ):
-            assert False, f"Could not ping {address} from f{expected_release_name}-xrd1-0"
+            assert (
+                False
+            ), f"Could not ping {address} from f{expected_release_name}-xrd1-0"
 
     for address in ("10.0.2.11", "10.0.3.11"):
         if not utils.wait_until(
@@ -122,4 +125,6 @@ def test_quickstart(kubectl: Kubectl, helm: Helm) -> None:
             f"{expected_release_name}-xrd2-0",
             address,
         ):
-            assert False, f"Could not ping {address} from f{expected_release_name}-xrd2-0"
+            assert (
+                False
+            ), f"Could not ping {address} from f{expected_release_name}-xrd2-0"

--- a/test/test_overlay.py
+++ b/test/test_overlay.py
@@ -4,6 +4,7 @@
 
 
 import pytest
+import subprocess
 
 from . import utils
 from ._types import Image, Kubectl, Platform

--- a/test/test_singleton.py
+++ b/test/test_singleton.py
@@ -13,39 +13,6 @@ from ._types import Image, Kubectl, Platform
 from .helm import Helm
 
 
-def check_ping(kubectl: Kubectl, pod_name: str, address: str) -> bool:
-    """
-    Check whether it is possible to ping a given address from a given pod.
-
-    :param kubectl:
-        Kubectl context.
-
-    :param pod_name:
-        Pod from which to ping.
-
-    :param address:
-        IP address to ping.
-
-    :return:
-        True if ping is successful.
-        False otherwise.
-
-    """
-    try:
-        p = kubectl(
-            "exec",
-            pod_name,
-            "--",
-            "xrenv",
-            "ping",
-            address,
-        )
-    except subprocess.CalledProcessError:
-        return False
-
-    return "!!!!!" in p.stdout
-
-
 @pytest.fixture(autouse=True)
 def uninstall_releases(helm: Helm) -> None:
     """Uninstall all Helm releases before and after each test case."""
@@ -207,7 +174,7 @@ def test_default_cni(image: Image, kubectl: Kubectl, helm: Helm) -> None:
     )
 
     if not utils.wait_until(
-        5, 60, check_ping, kubectl, f"xrd-{image.platform}-0", address
+        5, 60, utils.check_ping, kubectl, f"xrd-{image.platform}-0", address
     ):
         assert False, f"Could not ping {address}"
 
@@ -252,6 +219,6 @@ def test_pci_last(image: Image, kubectl: Kubectl, helm: Helm):
     )
 
     if not utils.wait_until(
-        5, 60, check_ping, kubectl, f"xrd-{image.platform}-0", address
+        5, 60, utils.check_ping, kubectl, f"xrd-{image.platform}-0", address
     ):
         assert False, f"Could not ping {address}"

--- a/test/utils.py
+++ b/test/utils.py
@@ -12,6 +12,7 @@ import shlex
 import subprocess
 import time
 from typing import Callable
+from ._types import Kubectl
 
 
 logger = logging.getLogger(__name__)

--- a/test/utils.py
+++ b/test/utils.py
@@ -12,6 +12,7 @@ import shlex
 import subprocess
 import time
 from typing import Callable
+
 from ._types import Kubectl
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,6 +1,7 @@
 # utils.py
 
 __all__ = (
+    "check_ping",
     "run_cmd",
     "wait_until",
 )
@@ -14,6 +15,39 @@ from typing import Callable
 
 
 logger = logging.getLogger(__name__)
+
+
+def check_ping(kubectl: Kubectl, pod_name: str, address: str) -> bool:
+    """
+    Check whether it is possible to ping a given address from a given pod.
+
+    :param kubectl:
+        Kubectl context.
+
+    :param pod_name:
+        Pod from which to ping.
+
+    :param address:
+        IP address to ping.
+
+    :return:
+        True if ping is successful.
+        False otherwise.
+
+    """
+    try:
+        p = kubectl(
+            "exec",
+            pod_name,
+            "--",
+            "xrenv",
+            "ping",
+            address,
+        )
+    except subprocess.CalledProcessError:
+        return False
+
+    return "!!!!!" in p.stdout
 
 
 def run_cmd(


### PR DESCRIPTION
Fixes #9.

Also:
* Update Jenkins pipeline to delete the bucket at the start of the e2e test (i.e. this implicitly tests this PR).
* Some Jenkinsfile whitespace changes (sorry)
* Do not parametrize `test_quickstart` by `Image`.  This test checks that the QuickStart create-stack installs the overlay Helm chart using a certain single image, and does not install/uninstall any charts.
* Retry `ping` for up to 60 seconds in `test_quickstart`.  This hopefully fixes a timing condition failure we have seen intermittently in the e2e tests, where BGP is established but pinging the peer does not immediately succeed.