### PR TITLE
Pass K8s version from example stack to application stack

### DIFF
--- a/cf-templates/xrd-example-cf.yaml
+++ b/cf-templates/xrd-example-cf.yaml
@@ -277,6 +277,7 @@ Resources:
         HelmReleaseName: !Ref HelmReleaseName
         XrdRootUserName: !Ref XrdRootUserName
         XrdRootPassword: !Ref XrdRootPassword
+        KubernetesVersion: !Ref KubernetesVersion
 
 
 Outputs:


### PR DESCRIPTION
The example stack `xrd-example` does not pass `KubernetesVersion` through to the application stack.

This means if you launch `xrd-example` with Kubernetes version 1.23, the Control Plane comes up at 1.23, but the worker nodes use the 1.22 AMI.

This was missed when testing #8, because I used the workflow of keeping the VPC and EKS cluster up, and installing/uninstalling the Application on top of this (which works correctly); and I did not spot this when running the e2e test.