### PR TITLE
Add default SubnetId for AMI template

### DIFF
--- a/cf-templates/xrd-eks-ami-cf.yaml
+++ b/cf-templates/xrd-eks-ami-cf.yaml
@@ -38,6 +38,7 @@ Parameters:
   SubnetId:
     Description: Subnet where the instance building the AMI is launched. If left empty this uses the default subnet.
     Type: String
+    Default: ""
 
 Conditions:
   EnsureEksQsSharedResources: !Equals [ !Ref EksQsSharedResources, 'AutoDetect' ]


### PR DESCRIPTION
#10 allows a SubnetId to be specified in the AMI template (with "" meaning don't pass a SubnetId to `AWS::EC2::Instance`.  But a default is not specified, so this field is now required, and callers were not updated.

This PR adds a default of "" to preserve the old behaviour.