### PR TITLE
Add IPv6 EKS limitation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ expression, as opposed to being limited to a static template.
 * `xrd-eks-existing-vpc` - Create an IPv4 EKS control plane suitable for running XRd using an existing VPC.
   * Augments `amazon-eks-entrypoint-existing-vpc` with XRd K8S settings and installs Multus.
   * Includes provisioning a Bastion for access to worker nodes
-  * IPv6 EKS clusters are not supported.
+  * This template does not support launching an IPv6 EKS cluster.
 * `xrd-eks-ami` - Creates an AMI for the EKS worker node which is able to run XRd vRouter.
   * Builds and installs a patched version of the `igb_uio` driver to add `write-combine` supported which in turn is needed to achieve high volume and low latency on AWS ENA interfaces.
   * Installs a `tuned` profile to isolate cores and prevent interrupts from running on data processing cores etc.

--- a/README.md
+++ b/README.md
@@ -213,9 +213,10 @@ expression, as opposed to being limited to a static template.
 * `xrd-vpc` - Create VPC suitable for running XRd.
   * Augments `aws-vpc` with additional subnets to build network topologies with.
   * These subnets are tagged so that topologies can be built referring to the tag rather than the SubnetId which varies every time a new VPC is created.
-* `xrd-eks-existing-vpc` - Create EKS control plane suitable for running XRd using an existing VPC.
+* `xrd-eks-existing-vpc` - Create an IPv4 EKS control plane suitable for running XRd using an existing VPC.
   * Augments `amazon-eks-entrypoint-existing-vpc` with XRd K8S settings and installs Multus.
   * Includes provisioning a Bastion for access to worker nodes
+  * IPv6 EKS clusters are not supported.
 * `xrd-eks-ami` - Creates an AMI for the EKS worker node which is able to run XRd vRouter.
   * Builds and installs a patched version of the `igb_uio` driver to add `write-combine` supported which in turn is needed to achieve high volume and low latency on AWS ENA interfaces.
   * Installs a `tuned` profile to isolate cores and prevent interrupts from running on data processing cores etc.


### PR DESCRIPTION
Add the limitation that we only support launching an IPv4 cluster to the README.