### PR TITLE
Add coredump configuration to AMI setup

### DIFF
--- a/ami_assets/etc/systemd/coredump.conf
+++ b/ami_assets/etc/systemd/coredump.conf
@@ -1,16 +1,3 @@
-#  This file is part of systemd.
-#
-#  systemd is free software; you can redistribute it and/or modify it
-#  under the terms of the GNU Lesser General Public License as published by
-#  the Free Software Foundation; either version 2.1 of the License, or
-#  (at your option) any later version.
-#
-# Entries in this file show the compile time defaults.
-# You can change settings by editing this file.
-# Defaults can be restored by simply deleting this file.
-#
-# See coredump.conf(5) for details.
-
 [Coredump]
 Storage=external
 Compress=yes
@@ -18,10 +5,3 @@ ProcessSizeMax=32G
 ExternalSizeMax=32G
 MaxUse=32G
 KeepFree=16G
-#Storage=external
-#Compress=yes
-#ProcessSizeMax=2G
-#ExternalSizeMax=2G
-#JournalSizeMax=767M
-#MaxUse=
-#KeepFree=

--- a/ami_assets/etc/systemd/coredump.conf
+++ b/ami_assets/etc/systemd/coredump.conf
@@ -1,0 +1,27 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See coredump.conf(5) for details.
+
+[Coredump]
+Storage=external
+Compress=yes
+ProcessSizeMax=32G
+ExternalSizeMax=32G
+MaxUse=32G
+KeepFree=16G
+#Storage=external
+#Compress=yes
+#ProcessSizeMax=2G
+#ExternalSizeMax=2G
+#JournalSizeMax=767M
+#MaxUse=
+#KeepFree=

--- a/ami_assets/etc/tuned/xrd-eks-node/tuned.conf
+++ b/ami_assets/etc/tuned/xrd-eks-node/tuned.conf
@@ -5,11 +5,5 @@ include=realtime-virtual-guest
 [variables]
 include=/etc/tuned/xrd-eks-node-variables.conf
 
-[sysctl]
-kernel.core_pattern=/core/%e_%p.by.%s.%t.%h.core
-# These must be overridden in /etc/sysctl.conf
-#fs.inotify.max_user_instances=65536
-#fs.inotify.max_user_watches=65536
-
 [bootloader]
 cmdline_xrd+=default_hugepagesz=1G hugepagesz=1G hugepages=${hugepages_gb}

--- a/ami_assets/etc/xrd/xrd-vrouter-build-ami.sh
+++ b/ami_assets/etc/xrd/xrd-vrouter-build-ami.sh
@@ -30,6 +30,7 @@ AMI_ASSETS="""
 /etc/modules-load.d/vfio-pci.conf
 /etc/modules-load.d/uio.conf
 /etc/modules-load.d/igb_uio.conf
+/etc/systemd/coredump.conf
 /etc/tuned/xrd-eks-node-variables.conf
 /etc/tuned/xrd-eks-node/defirqaffinity.py
 /etc/tuned/xrd-eks-node/tuned.conf

--- a/cf-templates/xrd-eks-node-launch-template-cf.yaml
+++ b/cf-templates/xrd-eks-node-launch-template-cf.yaml
@@ -449,6 +449,7 @@ Resources:
                   echo "net.core.netdev_max_backlog=300000" >> /etc/sysctl.conf
                   echo "net.core.optmem_max=67108864" >> /etc/sysctl.conf
                   echo "net.ipv4.udp_mem=1124736 10000000 67108864" >> /etc/sysctl.conf
+                  echo "kernel.core_pattern=|/lib/systemd/systemd-coredump %P %u %g %s %t 9223372036854775808 %h" >> /etc/sysctl.conf
                   sysctl -p --system
                   ${VRouterSetup}
                   ${ProxySetup}


### PR DESCRIPTION
Add coredump configuration in line with XRd recommendations to the example AMI.

This has been tested by running the AMI creation CF successfully, and checking a core is created and stored correctly by injecting SIGSEGV signals into XRd processes running on the node.