### PR TITLE
Delete AMI in e2e tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
     stages {
         stage("Remove existing XRd S3 bucket") {
             steps {
-                sh "aws s3 rb s3://${env.BUCKET_NAME} --force"
+                sh "aws s3 rb s3://${env.BUCKET_NAME} --force || true"
             }
         }
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@
 
 """Pytest hooks and fixtures."""
 
+import boto3
 import subprocess
 import warnings
 from pathlib import Path
@@ -219,6 +220,11 @@ def stack(
     finally:
         if test is not None and not request.config.option.aws_skip_teardown:
             test.clean_up()
+
+            # Delete the XRd AMI that was created.
+            cf = boto3.client("cloudformation")
+            version = request.config.option.eks_kubernetes_version.replace(".", "-")
+            cf.delete_stack(StackName=f"xrd-quickstart-AMI-{version}")
 
 
 @pytest.fixture(scope="session")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,12 +2,12 @@
 
 """Pytest hooks and fixtures."""
 
-import boto3
 import subprocess
 import warnings
 from pathlib import Path
 from typing import Optional
 
+import boto3
 import pytest
 
 from . import utils

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
 awscli
+boto3
 pytest
 taskcat


### PR DESCRIPTION
Delete the XRd AMI after running the e2e test suite.

Do this by removing the CF stack that creates the AMI.  This stack is created by a lambda deep in the CF templates (i.e. it's a completely isolated stack that doesn't have the example Application stack as it's parent), so just do this via boto3.

Note that if stack deletion fails this raises an error - this is deliberate (I assume we want to know if this fails).

Hardcode the stack name (this is hardcoded in the CF templates anyway).

