### PR TITLE
Add tags to S3 bucket indicating public contents for Cisco Security tooling

### DIFF
--- a/publish-s3-bucket
+++ b/publish-s3-bucket
@@ -165,6 +165,10 @@ create_bucket() {
 
     aws s3api put-public-access-block --bucket "${BUCKET_NAME}" --public-access-block-configuration "BlockPublicPolicy=false"
     aws s3api put-bucket-policy --bucket "${BUCKET_NAME}" --policy "${POLICY}"
+
+    aws s3api put-bucket-tagging \
+        --bucket "${BUCKET_NAME}" \
+        --tagging "TagSet=[{Key='Data Classification',Value='Cisco Public'},{Key=IntendedPublic,Value=true}]"
 }
 
 sync_dir() {


### PR DESCRIPTION
Add two tags to the S3 bucket created by `publish-s3-bucket` to indicate the contents of the bucket are public.

These are required for the Cisco security tooling, and will have no effect for external users.