### PR TITLE
Remove Rancher submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "submodules/quickstart-amazon-eks"]
 	path = submodules/quickstart-amazon-eks
-	url = https://github.com/aws-quickstart/quickstart-amazon-eks.git
+	url = https://github.com/ios-xr/quickstart-amazon-eks.git
 [submodule "submodules/quickstart-aws-vpc"]
 	path = submodules/quickstart-aws-vpc
 	url = https://github.com/aws-quickstart/quickstart-aws-vpc.git

--- a/create-stack
+++ b/create-stack
@@ -161,6 +161,9 @@ set -x
 aws cloudformation delete-stack --stack-name "${STACK_NAME}" || true
 aws cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}" || true
 
+aws cloudformation delete-stack --stack-name eks-quickstart-RegionalSharedResources || true
+aws cloudformation wait stack-delete-complete --stack-name eks-quickstart-RegionalSharedResources || true
+
 # shellcheck disable=SC2086
 # Relying on word splitting to pass ${PARAMETERS} and CAPABILITIES as individual args.
 aws cloudformation create-stack --stack-name "${STACK_NAME}" \


### PR DESCRIPTION
Fixes https://github.com/ios-xr/xrd-eks/issues/22 by pointing quickstart-amazon-eks at our fork, which is pinned at the same commits but removes the Rancher submodule.

Also delete the RegionalSharedResources stack as part of `create-stack` so that no manual recovery is needed - this has the disadvantage that stack creation time is increased by 5-10mins.  The reviewer should consider whether this is appropriate, or whether this workaround should just be documented prominently.